### PR TITLE
Auth Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 build
 *.egg-info
+.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">= 3.8.1"
 dependencies = [
-    "guardrails-ai>=0.4.0",
+    "guardrails-ai>=0.4.2",
     "pydantic>=2.4.2",
     "tenacity>=8.1.0",
     "transformers>=4.11.3",


### PR DESCRIPTION
This PR uses the `api_key` kwargs from the context when constructing the OpenAI client.

Related to https://github.com/guardrails-ai/validator-hub-ui/pull/9

This will allow users to provide their own credentials when using this validator via the hub playground.