### PR TITLE
optimize to a single call instead of multiple calls per topic

### DIFF
--- a/validator/main.py
+++ b/validator/main.py
@@ -97,7 +97,7 @@ class RestrictToTopic(Validator):
         else:
             self._invalid_topics = invalid_topics
 
-        self._device = device if device in ["cpu", "mps"] else to_int(device)
+        self._device = device if device == "mps" else to_int(device)
         self._model = model
         self._disable_classifier = disable_classifier
         self._disable_llm = disable_llm
@@ -118,7 +118,7 @@ class RestrictToTopic(Validator):
             if score > self._model_threshold and topic in self._valid_topics:
                 succesfully_on_topic.append(topic)
             if score > self._model_threshold and topic in self._invalid_topics:
-                return FailResult(error_message=f"Invalid {topic} was found to be relevant.")
+                return FailResult(error_message=f"Invalid topic {topic} was found to be relevant.")
         if not succesfully_on_topic:
             return FailResult(error_message="No valid topic was found.")
         return self.get_topic_llm(text, candidate_topics)
@@ -211,7 +211,7 @@ class RestrictToTopic(Validator):
         classifier = pipeline(
             "zero-shot-classification",
             model=self._model,
-            device=self._device,
+            device="mps",
             hypothesis_template="This example has to do with topic {}.",
             multi_label=True
         )

--- a/validator/main.py
+++ b/validator/main.py
@@ -97,7 +97,7 @@ class RestrictToTopic(Validator):
         else:
             self._invalid_topics = invalid_topics
 
-        self._device = device if device == "mps" else to_int(device)
+        self._device = device if device in ["cpu", "mps"] else to_int(device)
         self._model = model
         self._disable_classifier = disable_classifier
         self._disable_llm = disable_llm
@@ -211,7 +211,7 @@ class RestrictToTopic(Validator):
         classifier = pipeline(
             "zero-shot-classification",
             model=self._model,
-            device="mps",
+            device=self._device,
             hypothesis_template="This example has to do with topic {}.",
             multi_label=True
         )

--- a/validator/main.py
+++ b/validator/main.py
@@ -97,7 +97,7 @@ class RestrictToTopic(Validator):
         else:
             self._invalid_topics = invalid_topics
 
-        self._device = device if device == "mps" else to_int(device)
+        self._device = device if device in ["cpu", "mps"] else to_int(device)
         self._model = model
         self._disable_classifier = disable_classifier
         self._disable_llm = disable_llm
@@ -118,7 +118,9 @@ class RestrictToTopic(Validator):
             if score > self._model_threshold and topic in self._valid_topics:
                 succesfully_on_topic.append(topic)
             if score > self._model_threshold and topic in self._invalid_topics:
-                return FailResult(error_message=f"Invalid topic {topic} was found to be relevant.")
+                return FailResult(
+                    error_message=f"Invalid topic {topic} was found to be relevant."
+                )
         if not succesfully_on_topic:
             return FailResult(error_message="No valid topic was found.")
         return self.get_topic_llm(text, candidate_topics)
@@ -211,9 +213,9 @@ class RestrictToTopic(Validator):
         classifier = pipeline(
             "zero-shot-classification",
             model=self._model,
-            device="mps",
+            device=self._device,
             hypothesis_template="This example has to do with topic {}.",
-            multi_label=True
+            multi_label=True,
         )
         result = classifier(text, candidate_topics)
         topics = result["labels"]
@@ -236,7 +238,6 @@ class RestrictToTopic(Validator):
         if bool(valid_topics.intersection(invalid_topics)):
             raise ValueError("A topic cannot be valid and invalid at the same time.")
 
-
         # Check which model(s) to use
         if self._disable_classifier and self._disable_llm:  # Error, no model set
             raise ValueError("Either classifier or llm must be enabled.")
@@ -248,13 +249,17 @@ class RestrictToTopic(Validator):
             return self.get_topic_llm(value, list(invalid_topics))
 
         # Use only Zero-Shot
-        topics, scores = self.get_topic_zero_shot(value, list(invalid_topics) + list(valid_topics))
+        topics, scores = self.get_topic_zero_shot(
+            value, list(invalid_topics) + list(valid_topics)
+        )
         succesfully_on_topic = []
         for score, topic in zip(scores, topics):
             if score > self._model_threshold and topic in self._valid_topics:
                 succesfully_on_topic.append(topic)
             if score > self._model_threshold and topic in self._invalid_topics:
-                return FailResult(error_message=f"Invalid {topic} was found to be relevant.")
+                return FailResult(
+                    error_message=f"Invalid {topic} was found to be relevant."
+                )
         if not succesfully_on_topic:
             return FailResult(error_message="No valid topic was found.")
         return PassResult()

--- a/validator/main.py
+++ b/validator/main.py
@@ -108,6 +108,13 @@ class RestrictToTopic(Validator):
             self._model_threshold = model_threshold
 
         self.set_callable(llm_callable)
+        self.classifier = pipeline(
+            "zero-shot-classification",
+            model=self._model,
+            device=self._device,
+            hypothesis_template="This example has to do with topic {}.",
+            multi_label=True,
+        )
 
     def get_topic_ensemble(
         self, text: str, candidate_topics: List[str]
@@ -210,14 +217,8 @@ class RestrictToTopic(Validator):
     def get_topic_zero_shot(
         self, text: str, candidate_topics: List[str]
     ) -> Tuple[str, float]:
-        classifier = pipeline(
-            "zero-shot-classification",
-            model=self._model,
-            device=self._device,
-            hypothesis_template="This example has to do with topic {}.",
-            multi_label=True,
-        )
-        result = classifier(text, candidate_topics)
+
+        result = self.classifier(text, candidate_topics)
         topics = result["labels"]
         scores = result["scores"]
         return topics, scores


### PR DESCRIPTION
This update was created due to concerns with the speed of inference. Users were getting upwards of 10 seconds or longer for a single validation call.

This update changes the functionality to use multi topic prediction. Instead of 1 transformer call per topic, it makes 1 transformer call total. 

This would most likely affect the performance (in terms of accuracy) by some degree, as it removes the detection of "other" in data input. However it still has the same generic functionality and is much more efficient. 