### PR TITLE
Fix valid_topics/invalid_topics in metadata.

### DIFF
--- a/validator/main.py
+++ b/validator/main.py
@@ -322,9 +322,9 @@ class RestrictToTopic(Validator):
         invalid_topics_found = []
         valid_topics_found = []
         for topic in found_topics:
-            if topic in self._valid_topics:
+            if topic in valid_topics:
                 valid_topics_found.append(topic)
-            elif topic in self._invalid_topics:
+            elif topic in invalid_topics:
                 invalid_topics_found.append(topic)
 
         error_spans = []


### PR DESCRIPTION
If valid_topics or invalid_topics are provided via metadata instead of as init params the check at the end will fail to detect them.